### PR TITLE
Prototype/26/extra bomb powerup

### DIFF
--- a/client/src/components/bomb-controls/component.js
+++ b/client/src/components/bomb-controls/component.js
@@ -81,9 +81,6 @@ const BombControls = {
 			type
 		} = event.detail;
 
-		console.log("adding", type)
-
-
 		switch(type){
 			case "extra-bomb":
 				this.limit = Math.min(this.limit + 1, CONFIG.maxLimit);

--- a/client/src/components/bomb-controls/component.js
+++ b/client/src/components/bomb-controls/component.js
@@ -78,14 +78,23 @@ const BombControls = {
 	},// exploded
 	applyPowerup(event){
 		const { 
-			type, 
-			value 
+			type
 		} = event.detail;
 
 
 		switch(type){
 			case "extra-bomb":
-				this.limit  = Math.min(this.limit + 1, CONFIG.maxLimit);
+				this.limit = Math.min(this.limit + 1, CONFIG.maxLimit);
+				break;
+			case "max-bomb":
+				this.limit = CONFIG.maxLimit;
+				break;
+
+			case "extra-flame":
+				this.blastRadius = Math.min(this.blastRadius + 1, CONFIG.blastRadius);
+				break;
+			case "max-flame":
+				this.blastRadius = CONFIG.maxBlastRadius;
 				break;
 		}
 	},// applyPowerup

--- a/client/src/components/bomb-controls/component.js
+++ b/client/src/components/bomb-controls/component.js
@@ -16,6 +16,7 @@ const BombControls = {
 		this.dropBomb          = this.dropBomb.bind(this);
 		this.updateCurrentTile = this.updateCurrentTile.bind(this);
 		this.exploded          = this.exploded.bind(this);
+		this.applyPowerup = this.applyPowerup.bind(this);
 
 		// config
 		this.limit       = CONFIG.limit;
@@ -33,6 +34,9 @@ const BombControls = {
 
 		// update internal ref for current tile whenever the player moves onto a new one
 		el.addEventListener("raycaster-intersection", this.updateCurrentTile);
+
+		// apply the effects of any collected powerup
+		el.addEventListener("powerup__collect", this.applyPowerup);
 	}, // remove
 	remove(){
 
@@ -72,6 +76,19 @@ const BombControls = {
 		// clear-up space for another bomb
 		this.count--;
 	},// exploded
+	applyPowerup(event){
+		const { 
+			type, 
+			value 
+		} = event.detail;
+
+
+		switch(type){
+			case "extra-bomb":
+				this.limit  = Math.min(this.limit + 1, CONFIG.maxLimit);
+				break;
+		}
+	},// applyPowerup
 
 	// UTILS
 	// ------------------------------

--- a/client/src/components/bomb-controls/component.js
+++ b/client/src/components/bomb-controls/component.js
@@ -81,6 +81,8 @@ const BombControls = {
 			type
 		} = event.detail;
 
+		console.log("adding", type)
+
 
 		switch(type){
 			case "extra-bomb":
@@ -91,8 +93,9 @@ const BombControls = {
 				break;
 
 			case "extra-flame":
-				this.blastRadius = Math.min(this.blastRadius + 1, CONFIG.blastRadius);
+				this.blastRadius = Math.min(this.blastRadius + 1, CONFIG.maxBlastRadius);
 				break;
+
 			case "max-flame":
 				this.blastRadius = CONFIG.maxBlastRadius;
 				break;

--- a/client/src/components/bomb-controls/config.json
+++ b/client/src/components/bomb-controls/config.json
@@ -1,5 +1,7 @@
 {
-	"limit": 15,
+	"limit": 1,
+	"maxLimit": 5,
 	"lifespan": 2000,
-	"blastRadius": 5
+	"blastRadius": 1,
+	"maxBlastRadius": 5
 }

--- a/client/src/components/movement-controls/component.js
+++ b/client/src/components/movement-controls/component.js
@@ -6,14 +6,21 @@ const MovementControls = {
 	// LIFECYCLE JAZZ
 	// ---------------------------------
 	init(){
+
+		const {
+			el
+		} = this;
+
 		// scope binding
 		this.updateMovement = this.updateMovement.bind(this);
+		this.applyPowerup   = this.applyPowerup.bind(this);
 
 		// state
 		this.goUp      = false;
 		this.goRight   = false;
 		this.goDown    = false;
 		this.goLeft    = false;
+		this.velocity  = CONFIG.velocity;
 		this.xVelocity = 0;
 		this.zVelocity = 0;
 
@@ -23,6 +30,9 @@ const MovementControls = {
 		// add listeners
 		window.addEventListener("keydown", this.updateMovement);
 		window.addEventListener("keyup", this.updateMovement);
+
+		// apply the effects of any collected powerup
+		el.addEventListener("powerup__collect", this.applyPowerup);
 	},// init
 
 	tick(time, deltaTime){
@@ -59,8 +69,8 @@ const MovementControls = {
 			case "d":
 			case "D": {
 				this.goRight   = pressed;
-				this.xVelocity = pressed ? CONFIG.velocity : (
-					this.goLeft ? -CONFIG.velocity : 0
+				this.xVelocity = pressed ? this.velocity : (
+					this.goLeft ? -this.velocity : 0
 				);
 				break;
 			}
@@ -69,8 +79,8 @@ const MovementControls = {
 			case "a":
 			case "A": {
 				this.goLeft    = pressed;
-				this.xVelocity = pressed ? -CONFIG.velocity : (
-					this.goRight ? CONFIG.velocity : 0
+				this.xVelocity = pressed ? -this.velocity : (
+					this.goRight ? this.velocity : 0
 				);
 				break;
 			}
@@ -79,8 +89,8 @@ const MovementControls = {
 			case "w":
 			case "W": {
 				this.goUp      = pressed;
-				this.zVelocity = pressed ? -CONFIG.velocity : (
-					this.goDown ? CONFIG.velocity : 0
+				this.zVelocity = pressed ? -this.velocity : (
+					this.goDown ? this.velocity : 0
 				);
 				break;
 			}
@@ -89,13 +99,27 @@ const MovementControls = {
 			case "s":
 			case "S": {
 				this.goDown    = pressed;
-				this.zVelocity = pressed ? CONFIG.velocity : (
-					this.goUp ? -CONFIG.velocity : 0
+				this.zVelocity = pressed ? this.velocity : (
+					this.goUp ? -this.velocity : 0
 				);
 				break;
 			}
 		}
-	}, // updateMovement
+	},// updateMovement
+	applyPowerup(event){
+		const { 
+			type // (string) what kind of powerup was collected
+		} = event.detail;
+
+		switch(type){
+			case "extra-speed":
+				this.velocity = Math.min(this.velocity + 1, CONFIG.maxVelocity);
+				break;
+			case "max-speed":
+				this.velocity = CONFIG.maxVelocity;
+				break;
+		}
+	}// applyPowerup
 };
 
 export default MovementControls;

--- a/client/src/components/movement-controls/config.json
+++ b/client/src/components/movement-controls/config.json
@@ -1,4 +1,5 @@
 {
 	"targetFPS": 16.67,
-	"velocity": 5
+	"velocity": 3,
+	"maxVelocity": 7
 }

--- a/client/src/elements/game-scene/template.js
+++ b/client/src/elements/game-scene/template.js
@@ -6,7 +6,6 @@ template.innerHTML = `
 	<a-scene 
 		class="${s.scene}"
 		physics="debug: true; gravity: 0;"
-		stats
 	>
 		<a-assets>
 			<img src="assets/3d/textures/crate.jpg" alt="Destructable block texture." id="texture__destructable__crate" />

--- a/client/src/primitives/a-bomb/a-bomb-explosion/a-bomb-explosion-flame/component.js
+++ b/client/src/primitives/a-bomb/a-bomb-explosion/a-bomb-explosion-flame/component.js
@@ -107,7 +107,7 @@ const Flame = {
 
 		// get the entities that were hit
 		const { intersections } = event.detail;
-		const [ intersection ]  = intersections;
+
 
 		// get the element and distance of everything that the raycaster hit...
 		for(let { object: { el: target }, distance } of intersections){

--- a/client/src/primitives/a-cell/component.js
+++ b/client/src/primitives/a-cell/component.js
@@ -18,6 +18,9 @@ const Cell = {
 			}
 		} = this;
 
+		// scope binding
+		this.generatePowerup = this.generatePowerup.bind(this);
+
 		// import the default contents of the cell
 		const contents = document.importNode(template.content, true);
 
@@ -26,11 +29,25 @@ const Cell = {
 			const boxType = destructable ? "a-destructable-box" : "a-indestructable-box";
 			const box     = document.createElement(boxType);
 
+			if(destructable){
+				box.addEventListener("destructable_box__destroyed", this.generatePowerup);
+			}
+
 			contents.appendChild(box);
 		}
 
 		el.appendChild(contents);
-	}// init
+	},// init
+
+	// EVENT HANDLERS
+	// ------------------------------
+	generatePowerup(){
+		const { el } = this;
+
+		const powerup = document.createElement("a-powerup");
+
+		el.appendChild(powerup);
+	}// generatePowerup
 };
 
 export default Cell;

--- a/client/src/primitives/a-cell/component.js
+++ b/client/src/primitives/a-cell/component.js
@@ -7,6 +7,9 @@ const Cell = {
 		},
 		empty: {
 			default: false
+		},
+		reward: {
+			default: 0.8
 		}
 	},
 	init(){
@@ -29,6 +32,7 @@ const Cell = {
 			const boxType = destructable ? "a-destructable-box" : "a-indestructable-box";
 			const box     = document.createElement(boxType);
 
+			// if it's destructable generate a powerup when it's destroyed
 			if(destructable){
 				box.addEventListener("destructable_box__destroyed", this.generatePowerup);
 			}
@@ -42,13 +46,20 @@ const Cell = {
 	// EVENT HANDLERS
 	// ------------------------------
 	generatePowerup(){
-		const { el } = this;
+		const { 
+			el,
+			data: {
+				reward // (number)[0-1] liklihood of generating a powerup
+			}
+		} = this;
 
-		const powerup = document.createElement("a-powerup");
-		powerup.setAttribute("type", "extra-bomb");
-		powerup.setAttribute("value", 1);
+		// roll a dice to determine if the block generates a powerup
+		const rewardRoll = Math.random();
 
-		el.appendChild(powerup);
+		if(rewardRoll < reward){
+			const powerup  = document.createElement("a-powerup");
+			el.appendChild(powerup);
+		}
 	}// generatePowerup
 };
 

--- a/client/src/primitives/a-cell/component.js
+++ b/client/src/primitives/a-cell/component.js
@@ -45,6 +45,8 @@ const Cell = {
 		const { el } = this;
 
 		const powerup = document.createElement("a-powerup");
+		powerup.setAttribute("type", "extra-bomb");
+		powerup.setAttribute("value", 1);
 
 		el.appendChild(powerup);
 	}// generatePowerup

--- a/client/src/primitives/a-destructable-box/component.js
+++ b/client/src/primitives/a-destructable-box/component.js
@@ -23,6 +23,7 @@ const DestructableBox = {
 	// --------------------------
 	destruct(){
 		const { el } = this;
+		el.emit("destructable_box__destroyed");
 		// remove from the scene
 		el.parentElement.removeChild(el);
 	}// destruct

--- a/client/src/primitives/a-player/component.js
+++ b/client/src/primitives/a-player/component.js
@@ -9,7 +9,6 @@ const Player = {
 
 		// scope binding
 		this.destruct = this.destruct.bind(this);
-		this.applyPowerup = this.applyPowerup.bind(this);
 
 		// add the player model to the entity
 		const contents = document.importNode(template.content, true);
@@ -19,8 +18,6 @@ const Player = {
 		// NOTE: the model is destructable, the wrapper isn't
 		el.addEventListener("explosion__destroyed", this.destruct);
 
-		// apply the effects of any collected powerup
-		el.addEventListener("powerup__collect", this.applyPowerup);
 	},// init
 
 	// EVENT HANDLING
@@ -30,10 +27,6 @@ const Player = {
 
 		el.parentEl.removeChild(el);
 	},// destruct
-
-	applyPowerup(event){
-		console.log({ event });
-	}// applyPowerup
 };
 
 export default Player;

--- a/client/src/primitives/a-player/component.js
+++ b/client/src/primitives/a-player/component.js
@@ -9,6 +9,7 @@ const Player = {
 
 		// scope binding
 		this.destruct = this.destruct.bind(this);
+		this.applyPowerup = this.applyPowerup.bind(this);
 
 		// add the player model to the entity
 		const contents = document.importNode(template.content, true);
@@ -17,15 +18,22 @@ const Player = {
 		// remove this entity when it's hit by an explosion
 		// NOTE: the model is destructable, the wrapper isn't
 		el.addEventListener("explosion__destroyed", this.destruct);
+
+		// apply the effects of any collected powerup
+		el.addEventListener("powerup__collect", this.applyPowerup);
 	},// init
 
-	// UTILS
+	// EVENT HANDLING
 	// --------------------------
-	destruct(){
+	destruct(event){
 		const { el } = this;
 
 		el.parentEl.removeChild(el);
-	}// destruct
+	},// destruct
+
+	applyPowerup(event){
+		console.log({ event });
+	}// applyPowerup
 };
 
 export default Player;

--- a/client/src/primitives/a-powerup/component.js
+++ b/client/src/primitives/a-powerup/component.js
@@ -1,13 +1,11 @@
+import { UTILS } from "SHARED/";
+import { CONFIG } from "./";
+
 const Powerup = {
 	schema: {
 		type: {
-			type: "string",
-			default: "extra-bomb"
+			type: "string"
 		},
-		value: {
-			type: "number",
-			default: 1
-		}
 	},
 
 	// LIFECYCLE JAZZ
@@ -16,17 +14,25 @@ const Powerup = {
 		const {
 			el,
 			data: {
-				type
+				type: definedType
 			}
 		} = this;
 
 		// scope binding
-		this.pickup  = this.pickup.bind(this);
-		this.destroy = this.destroy.bind(this);
+		this.pickup             = this.pickup.bind(this);
+		this.destroy            = this.destroy.bind(this);
+		this.generateRandomType = this.generateRandomType.bind(this);
+
+		const { name, material } = this.generateRandomType(CONFIG.types);
+
+		// update the type if we had to add it ourselves
+		if(!definedType) el.setAttribute("type", name);
+
+		// apply a texture to match the given type
+		el.setAttribute("material", `color: ${material}`);
 
 		el.addEventListener("collide", this.pickup);
 	}, // init
-
 
 	// EVENT HANDLING
 	// ---------------------------
@@ -34,13 +40,12 @@ const Powerup = {
 		const { 
 			el,
 			data: {
-				type,
-				value
+				type
 			}
 		} = this;
 		const { el: player } = event.detail.body;
-		const details        = {
-			type, value
+		const details = {
+			type  // (string) the type of powerup that was collected
 		};
 
 		el.removeEventListener("collide", this.pickup);
@@ -51,6 +56,10 @@ const Powerup = {
 
 	// UTILS
 	// --------------------------
+	generateRandomType(types){
+		const index = UTILS.randomInt(0, types.length-1);
+		return types[index];
+	},// generateRandomType
 	destroy(){
 		const { el } = this;
 		el.parentElement.removeChild(el);

--- a/client/src/primitives/a-powerup/component.js
+++ b/client/src/primitives/a-powerup/component.js
@@ -20,7 +20,7 @@ const Powerup = {
 
 		// scope binding
 		this.pickup             = this.pickup.bind(this);
-		this.destroy            = this.destroy.bind(this);
+		this.destruct           = this.destruct.bind(this);
 		this.generateRandomType = this.generateRandomType.bind(this);
 
 
@@ -38,6 +38,9 @@ const Powerup = {
 
 		// pick-up this powerup when you walk into it
 		el.addEventListener("collide", this.pickup);
+
+		// destroy the pickup if it's hit by an explosion
+		el.addEventListener("explosion__destroyed", this.destruct);
 
 		// add template to the DOM
 		el.appendChild(contents);
@@ -60,7 +63,7 @@ const Powerup = {
 		el.removeEventListener("collide", this.pickup);
 
 		player.emit("powerup__collect", details);
-		this.destroy();
+		this.destruct();
 	},// pickup
 
 	// UTILS
@@ -82,10 +85,10 @@ const Powerup = {
 		}
 		return type;
 	},// generateRandomType
-	destroy(){
+	destruct(){
 		const { el } = this;
 		el.parentElement.removeChild(el);
-	}// destroy	
+	}// destruct	
 };
 
 export default Powerup;

--- a/client/src/primitives/a-powerup/component.js
+++ b/client/src/primitives/a-powerup/component.js
@@ -1,0 +1,60 @@
+const Powerup = {
+	schema: {
+		type: {
+			type: "string",
+			default: "extra-bomb"
+		},
+		value: {
+			type: "number",
+			default: 1
+		}
+	},
+
+	// LIFECYCLE JAZZ
+	// ----------------------------
+	init(){
+		const {
+			el,
+			data: {
+				type
+			}
+		} = this;
+
+		// scope binding
+		this.pickup  = this.pickup.bind(this);
+		this.destroy = this.destroy.bind(this);
+
+		el.addEventListener("collide", this.pickup);
+	}, // init
+
+
+	// EVENT HANDLING
+	// ---------------------------
+	pickup(event){
+		const { 
+			el,
+			data: {
+				type,
+				value
+			}
+		} = this;
+		const { el: player } = event.detail.body;
+		const details        = {
+			type, value
+		};
+
+		el.removeEventListener("collide", this.pickup);
+
+		player.emit("powerup__collect", details);
+		this.destroy();
+	},// pickup
+
+	// UTILS
+	// --------------------------
+	destroy(){
+		const { el } = this;
+		el.parentElement.removeChild(el);
+	}// destroy	
+};
+
+export default Powerup;

--- a/client/src/primitives/a-powerup/component.js
+++ b/client/src/primitives/a-powerup/component.js
@@ -31,6 +31,7 @@ const Powerup = {
 		// apply a texture to match the given type
 		el.setAttribute("material", `color: ${material}`);
 
+		// pick-up this powerup when you walk into it
 		el.addEventListener("collide", this.pickup);
 	}, // init
 
@@ -57,8 +58,21 @@ const Powerup = {
 	// UTILS
 	// --------------------------
 	generateRandomType(types){
-		const index = UTILS.randomInt(0, types.length-1);
-		return types[index];
+		const index     = UTILS.randomInt(0, types.length-1);
+		const powerup   = types[index];
+
+		let type = powerup;
+
+		// if there's a 'max' variant to the powerup, roll for it
+		if(powerup.max){
+			const { chance } = powerup.max;
+			const bonusRoll = Math.random();
+
+			if(bonusRoll < chance){
+				type = powerup.max;
+			}
+		}
+		return type;
 	},// generateRandomType
 	destroy(){
 		const { el } = this;

--- a/client/src/primitives/a-powerup/component.js
+++ b/client/src/primitives/a-powerup/component.js
@@ -1,5 +1,5 @@
 import { UTILS } from "SHARED/";
-import { CONFIG } from "./";
+import { CONFIG, template } from "./";
 
 const Powerup = {
 	schema: {
@@ -23,16 +23,24 @@ const Powerup = {
 		this.destroy            = this.destroy.bind(this);
 		this.generateRandomType = this.generateRandomType.bind(this);
 
+
+		// create the powerup model
+		const contents = document.importNode(template.content, true);
+		const model    = contents.querySelector(".pickup__entity");
+
 		const { name, material } = this.generateRandomType(CONFIG.types);
 
 		// update the type if we had to add it ourselves
 		if(!definedType) el.setAttribute("type", name);
 
 		// apply a texture to match the given type
-		el.setAttribute("material", `color: ${material}`);
+		model.setAttribute("material", `color: ${material}`);
 
 		// pick-up this powerup when you walk into it
 		el.addEventListener("collide", this.pickup);
+
+		// add template to the DOM
+		el.appendChild(contents);
 	}, // init
 
 	// EVENT HANDLING

--- a/client/src/primitives/a-powerup/config.json
+++ b/client/src/primitives/a-powerup/config.json
@@ -2,22 +2,28 @@
 	"types": [
 		{
 			"name": "extra-bomb",
-			"material": "#68c0e3"
-		}, {
-			"name": "max-bombs",
-			"material": "#1b63cf"
+			"material": "#68c0e3",
+			"max": {
+				"name": "max-bombs",
+				"material": "#1b63cf",
+				"chance": 0.01
+			}
 		}, {
 			"name": "extra-flame",
-			"material": "#c91616"
-		}, {
-			"name": "max-flame",
-			"material": "#ff4800"
+			"material": "#c91616",
+			"max": {
+				"name": "max-flame",
+				"material": "#ff4800",
+				"chance": 0.01
+			}
 		}, {
 			"name": "extra-speed",
-			"material": "#bfcf65"
-		}, {
-			"name": "max-speed",
-			"material": "#c3e30e"
+			"material": "#bfcf65",
+			"max": {
+				"name": "max-speed",
+				"material": "#c3e30e",
+				"chance": 0.01
+			}
 		}
 	]
 }

--- a/client/src/primitives/a-powerup/config.json
+++ b/client/src/primitives/a-powerup/config.json
@@ -1,0 +1,23 @@
+{
+	"types": [
+		{
+			"name": "extra-bomb",
+			"material": "#68c0e3"
+		}, {
+			"name": "max-bombs",
+			"material": "#1b63cf"
+		}, {
+			"name": "extra-flame",
+			"material": "#c91616"
+		}, {
+			"name": "max-flame",
+			"material": "#ff4800"
+		}, {
+			"name": "extra-speed",
+			"material": "#bfcf65"
+		}, {
+			"name": "max-speed",
+			"material": "#c3e30e"
+		}
+	]
+}

--- a/client/src/primitives/a-powerup/index.js
+++ b/client/src/primitives/a-powerup/index.js
@@ -1,0 +1,8 @@
+import componentDefinition from "./component.js";
+import primitiveDefinition from "./primitive.js";
+
+const component = { "powerup" : componentDefinition };
+const primitive = { "a-powerup" : primitiveDefinition };
+
+export { component, primitive };
+export default primitive;

--- a/client/src/primitives/a-powerup/index.js
+++ b/client/src/primitives/a-powerup/index.js
@@ -1,8 +1,10 @@
+import CONFIG from "./config.json";
+
 import componentDefinition from "./component.js";
 import primitiveDefinition from "./primitive.js";
 
 const component = { "powerup" : componentDefinition };
 const primitive = { "a-powerup" : primitiveDefinition };
 
-export { component, primitive };
+export { CONFIG, component, primitive };
 export default primitive;

--- a/client/src/primitives/a-powerup/index.js
+++ b/client/src/primitives/a-powerup/index.js
@@ -1,4 +1,5 @@
 import CONFIG from "./config.json";
+import template from "./template.js";
 
 import componentDefinition from "./component.js";
 import primitiveDefinition from "./primitive.js";
@@ -6,5 +7,5 @@ import primitiveDefinition from "./primitive.js";
 const component = { "powerup" : componentDefinition };
 const primitive = { "a-powerup" : primitiveDefinition };
 
-export { CONFIG, component, primitive };
+export { CONFIG, template, component, primitive };
 export default primitive;

--- a/client/src/primitives/a-powerup/primitive.js
+++ b/client/src/primitives/a-powerup/primitive.js
@@ -1,0 +1,27 @@
+const primitive = {
+	defaultComponents: {
+		powerup: {},
+		geometry: {
+			primitive: "box",
+		},
+		scale: "0.5 0.5 0.5",
+		material: {
+			color: "red"
+		},
+		rotation: "45 0 45",
+		position: "0 0.5 0",
+		"static-body": {
+			shape: "box"
+		},
+		animation__spin: {
+			property: "rotation",
+			from: "45 0 45",
+			to: "45 360 45",
+			easing: "linear",
+			dur: 5000,
+			loop: true
+		}
+	}
+};
+
+export default primitive;

--- a/client/src/primitives/a-powerup/primitive.js
+++ b/client/src/primitives/a-powerup/primitive.js
@@ -1,26 +1,9 @@
 const primitive = {
 	defaultComponents: {
 		powerup: {},
-		geometry: {
-			primitive: "box",
-		},
-		scale: "0.5 0.5 0.5",
-		material: {
-			color: "red"
-		},
-		rotation: "45 0 45",
-		position: "0 0.5 0",
 		"static-body": {
 			shape: "box"
 		},
-		animation__spin: {
-			property: "rotation",
-			from: "45 0 45",
-			to: "45 360 45",
-			easing: "linear",
-			dur: 5000,
-			loop: true
-		}
 	},
 	mappings: {
 		"type": "powerup.type",

--- a/client/src/primitives/a-powerup/primitive.js
+++ b/client/src/primitives/a-powerup/primitive.js
@@ -21,6 +21,10 @@ const primitive = {
 			dur: 5000,
 			loop: true
 		}
+	},
+	mappings: {
+		"type": "powerup.type",
+		"value": "powerup.value"
 	}
 };
 

--- a/client/src/primitives/a-powerup/template.js
+++ b/client/src/primitives/a-powerup/template.js
@@ -3,7 +3,9 @@ const template = document.createElement("template");
 template.innerHTML = `
 	<a-box 
 		class="pickup__entity explosion__destructable explosion__blocking"
-		scale="0.5 0.5 0.5"
+		height="0.5"
+		width="0.5"
+		depth="0.5"
 		rotation="45 0 45"
 		position="0 0.5 0"
 		animation="

--- a/client/src/primitives/a-powerup/template.js
+++ b/client/src/primitives/a-powerup/template.js
@@ -1,0 +1,20 @@
+const template = document.createElement("template");
+
+template.innerHTML = `
+	<a-box 
+		class="pickup__entity explosion__destructable explosion__blocking"
+		scale="0.5 0.5 0.5"
+		rotation="45 0 45"
+		position="0 0.5 0"
+		animation="
+			property: rotation;
+			from: 45 0 45;
+			to: 45 360 45;
+			easing: linear;
+			dur: 5000;
+			loop: true;
+		"
+	></a-box>
+`;
+
+export default template;

--- a/client/src/primitives/index.js
+++ b/client/src/primitives/index.js
@@ -8,6 +8,7 @@ import {
 	BombExplosion, BombExplosionComponent,
 	BombExplosionFlame, BombExplosionFlameComponent
 } from "./a-bomb/";
+import Powerup, { component as PowerupComponent } from "./a-powerup/";
 
 const components = [
 	CellComponent,
@@ -16,7 +17,8 @@ const components = [
 	PlayerComponent,
 	BombComponent,
 	BombExplosionComponent,
-	BombExplosionFlameComponent
+	BombExplosionFlameComponent,
+	PowerupComponent
 ];
 
 const primitives = [
@@ -26,7 +28,8 @@ const primitives = [
 	Player,
 	Bomb,
 	BombExplosion,
-	BombExplosionFlame
+	BombExplosionFlame,
+	Powerup
 ];
 
 export { components, primitives };

--- a/client/src/shared/index.js
+++ b/client/src/shared/index.js
@@ -1,3 +1,4 @@
 import CONFIG from "./config.json";
+import * as UTILS from "./utils.js";
 
-export { CONFIG };
+export { CONFIG, UTILS };

--- a/client/src/shared/utils.js
+++ b/client/src/shared/utils.js
@@ -1,0 +1,3 @@
+export function randomInt(min, max) {
+	return Math.floor(Math.random() * (max - min + 1) + min);
+}// randomInt


### PR DESCRIPTION
closes #26 and #27 

- adds an `<a-powerup>` primitive and `powerup` component that represents a collectable powerup
- `extra-bomb` powerup allows the user to place 1 more bomb than they usually would
- `extra-flame` powerup extends the radius of a bomb's explosion by an extra tile
- `extra-speed` powerup increases the velocity of the user by 1
- all powerups have a max variant which has a 1% chance to spawn
- all normal-level powerups have an equal level of spawning
- powerups can be destroyed by explosions